### PR TITLE
totalCount set before checking the lastObjectId condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,6 @@ app.use('/api/user', userRoutes);
 app.use('/api/tyre', tyreRoutes);
 
 // Start server
-app.listen(PORT, '0.0.0.0', () => {
+app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
The bug was totalTyreCount decreases by the page rendering size when move to the next page in pagination section. It is because total product count (totalTyres) is calculated when using cursor-based pagination. So Total product count added before checking the lastObjectId condition.